### PR TITLE
Remove lock from humidifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ A Homebridge plugin to provide comprehensive and intuitive control of Govee devi
     - Humidifiers (H7141, H7142)
         - Control Device Power
         - Control Device Mist Output Level
-        - Reports Device Water Level
-        - Lock/Unlock the Physical Controls on the Device
+        - Reports When Device Water Level is Empty
     - RGBIC Lights
         - Control the entire light's brightness and color
         - Control each of the 15 segments' color and relative brightness individually

--- a/src/platform/accessories/services/HumidifierService.ts
+++ b/src/platform/accessories/services/HumidifierService.ts
@@ -12,7 +12,6 @@ import {DeviceMistLevelTransition} from '../../../core/structures/devices/transi
 import {StatusModeState} from '../../../devices/states/StatusMode';
 import {LoggingService} from '../../../logging/LoggingService';
 import {ControlLockState} from '../../../devices/states/ControlLock';
-import {DeviceControlLockTransition} from '../../../core/structures/devices/transitions/DeviceControlLockTransition';
 import {ServiceRegistry} from '../ServiceRegistry';
 import {GoveeHumidifier} from '../../../devices/implmentations/GoveeHumidifier';
 import {PlatformConfigService} from '../../config/PlatformConfigService';
@@ -57,23 +56,6 @@ export class HumidifierService extends AccessoryService<void> {
         validValues: [100],
       })
       .updateValue(100);
-    service
-      .getCharacteristic(this.CHARACTERISTICS.LockPhysicalControls)
-      .updateValue(
-        (device as unknown as ControlLockState).areControlsLocked
-          ? this.CHARACTERISTICS.LockPhysicalControls.CONTROL_LOCK_ENABLED
-          : this.CHARACTERISTICS.LockPhysicalControls.CONTROL_LOCK_DISABLED)
-      .onSet(
-        async (value: CharacteristicValue) =>
-          this.emit(
-            new DeviceCommandEvent(
-              new DeviceControlLockTransition(
-                device.deviceId,
-                value === this.CHARACTERISTICS.LockPhysicalControls.CONTROL_LOCK_ENABLED,
-              ),
-            ),
-          ),
-      );
 
     service
       .getCharacteristic(this.CHARACTERISTICS.WaterLevel)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Turns out the humidifier does not actually support locking the physical controls, even though the operation states do.

## Related Issues
Fixes #21 

## Motivation and Context
Completeness more than anything

## How Has This Been Tested?
On HomeBridge

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
