### PR TITLE
Add H705A as RGBIC light

### DIFF
--- a/src/devices/implementations/GoveeRGBICLight.ts
+++ b/src/devices/implementations/GoveeRGBICLight.ts
@@ -10,6 +10,7 @@ import {ColorMode} from '../states/modes/Color';
   'H611A',
   'H6144',
   'H6072',
+  'H705A',
 )
 export class GoveeRGBICLight
   extends SceneMode(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

H705A are labeled as RGBIC - they do not look to be of variable length.

## Related Issues
Fixes #251

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
