### PR TITLE
Add H5109 to supported list

### DIFF
--- a/device.categories.json
+++ b/device.categories.json
@@ -3319,11 +3319,11 @@
               "online": true,
               "modelName": "Floating Sensor H5109",
               "iconUrl": "https://cdn.shopify.com/s/files/1/0512/3489/8105/files/87cbedd9fdfbacf2108f61729a57d9f8.jpg?v=1718160243",
-              "showingSku": "H5109001",
+              "showingSku": "H5109",
               "categoryId": 2,
               "products": [
                 {
-                  "sku": "H5109001",
+                  "sku": "H5109",
                   "goodsType": 8,
                   "skuUrl": "https://cdn.shopify.com/s/files/1/0512/3489/8105/files/87cbedd9fdfbacf2108f61729a57d9f8.jpg?v=1718160243",
                   "extInfo": "",

--- a/device.categories.json
+++ b/device.categories.json
@@ -3314,6 +3314,28 @@
               ]
             },
             {
+              "productId": -669,
+              "hintContent": "",
+              "online": true,
+              "modelName": "Floating Sensor H5109",
+              "iconUrl": "https://cdn.shopify.com/s/files/1/0512/3489/8105/files/87cbedd9fdfbacf2108f61729a57d9f8.jpg?v=1718160243",
+              "showingSku": "H5109001",
+              "categoryId": 2,
+              "products": [
+                {
+                  "sku": "H5109001",
+                  "goodsType": 8,
+                  "skuUrl": "https://cdn.shopify.com/s/files/1/0512/3489/8105/files/87cbedd9fdfbacf2108f61729a57d9f8.jpg?v=1718160243",
+                  "extInfo": "",
+                  "ic": 0,
+                  "pairUrl": {
+                    "light": "",
+                    "dark": ""
+                  }
+                }
+              ]
+            },
+            {
               "productId": 669,
               "hintContent": "",
               "online": true,


### PR DESCRIPTION
Details from https://us.govee.com/products/goveelife-smart-pool-thermometer-with-smart-gateway-1s?Style=1+Floating+Sensor

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds H5109 to the list of temp devices

Does not set the correct product Id (where does that even originate?)

<!--- Describe your changes in detail -->

## Related Issues

Fixes #

## Motivation and Context
Draft fix for https://github.com/constructorfleet/homebridge-ultimate-govee/issues/346
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
nope

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
